### PR TITLE
documentation: use legacy version of cnn

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This tool is used to generate morphologically inflected forms of a given word ac
 
 ###Requirements
 
-1. CNN neural network library: https://github.com/clab/cnn
+1. CNN neural network library: https://github.com/clab/cnn-v1
 2. C++ BOOST library: http://www.boost.org/
 3. C++ Eigen library: http://eigen.tuxfamily.org/
 


### PR DESCRIPTION
The `cnn` project was recently renamed to `dynet`. The latest version of `dynet` is not compatible to `morph-trans` (because of header changes and reorganizations).

This PR updates the `cnn` project link to the legacy version of `cnn`, now named `cnn-v1`.

`master` branch of `cnn-v1` is compatible with the recent `morph-trans` version, tested on Ubuntu 17.04.